### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/ridewithgps/base.py
+++ b/ridewithgps/base.py
@@ -44,9 +44,6 @@ class APIClient:
 
     def _compose_url(self, path, params=None):
         """Compose a full URL from path and query parameters."""
-        if params:
-            sanitized_params = {k: (v if k != "password" else "REDACTED") for k, v in params.items()}
-            print(sanitized_params)
         return self.BASE_URL + path + "?" + urlencode(params)
 
     def _handle_response(self, response):
@@ -56,7 +53,6 @@ class APIClient:
     def _request(self, method, path, params=None):
         """Make an HTTP request and return the parsed response."""
         url = self._compose_url(path, params)
-        print(url)
         if self.rate_limit_lock:
             self.rate_limit_lock.acquire()
         r = self.connection_pool.urlopen(method.upper(), url)

--- a/ridewithgps/base.py
+++ b/ridewithgps/base.py
@@ -44,7 +44,9 @@ class APIClient:
 
     def _compose_url(self, path, params=None):
         """Compose a full URL from path and query parameters."""
-        print(params)
+        if params:
+            sanitized_params = {k: (v if k != "password" else "REDACTED") for k, v in params.items()}
+            print(sanitized_params)
         return self.BASE_URL + path + "?" + urlencode(params)
 
     def _handle_response(self, response):


### PR DESCRIPTION
Potential fix for [https://github.com/ckdake/python-ridewithgps/security/code-scanning/6](https://github.com/ckdake/python-ridewithgps/security/code-scanning/6)

To fix the issue, we need to ensure that sensitive information, such as passwords, is not logged. Instead of logging the entire `params` dictionary, we can sanitize it by redacting sensitive fields (e.g., `password`) before logging. Alternatively, we can remove the `print(params)` statement entirely if logging the parameters is unnecessary.

The best approach is to redact sensitive fields from the `params` dictionary before logging. This ensures that debugging information is still available without exposing sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
